### PR TITLE
增加Swift对YYModel/MJExtension的支持

### DIFF
--- a/ESJsonFormatForMac/Controller/ESInputJsonController.m
+++ b/ESJsonFormatForMac/Controller/ESInputJsonController.m
@@ -685,10 +685,18 @@
                 //如果是 NSArray 取出第一个元素向下遍历
                 NSArray *array = obj;
                 if (array.firstObject) {
-                    NSObject *obj = [array firstObject];
+
+                    //将数组中每个元素有值的key汇合到一起
+                    NSMutableDictionary *useDic = @{}.mutableCopy;
+                    [array enumerateObjectsUsingBlock:^(id  _Nonnull obj2, NSUInteger idx, BOOL * _Nonnull stop) {
+                        if ([obj2 isKindOfClass:NSDictionary.class]) {
+                            [useDic addEntriesFromDictionary:obj2];
+                        }
+                    }];
+
                     //May be 'NSString'，will crash
-                    if ([obj isKindOfClass:[NSDictionary class]]) {
-                        ESClassInfo *childClassInfo = [[ESClassInfo alloc] initWithClassNameKey:key ClassName:childClassName classDic:(NSDictionary *)obj];
+                    if ([useDic isKindOfClass:[NSDictionary class]]) {
+                        ESClassInfo *childClassInfo = [[ESClassInfo alloc] initWithClassNameKey:key ClassName:childClassName classDic:(NSDictionary *)useDic];
                         [self dealPropertyNameWithClassInfo:childClassInfo];
                         //设置classInfo里面属性类型为 NSArray 情况下，NSArray 内部元素类型的对应的class
                         [classInfo.propertyArrayDic setObject:childClassInfo forKey:key];
@@ -786,7 +794,10 @@
         }else{
         
             //Swift
-            [self.hContentTextView insertText:classInfo.classContentForH];
+            //最顶层的类
+            NSMutableString *result = classInfo.classContentForH.mutableCopy;
+            [result appendString:@"\n"];
+            [self.hContentTextView insertText:result];
             
             //再添加把其他类的的字符串拼接到最后面
             [self.hContentTextView insertText:classInfo.classInsertTextViewContentForH replacementRange:NSMakeRange(self.hContentTextView.string.length, 0)];

--- a/ESJsonFormatForMac/Model/ESClassInfo.m
+++ b/ESJsonFormatForMac/Model/ESClassInfo.m
@@ -92,7 +92,7 @@
     NSMutableString *result = [NSMutableString stringWithFormat:@""];
     for (NSString *key in self.propertyClassDic) {
         ESClassInfo *classInfo = self.propertyClassDic[key];
-        [result appendFormat:@"%@\n\n",classInfo.classContentForH];
+        [result appendFormat:@"%@\n",classInfo.classContentForH];
         [result appendString:classInfo.classInsertTextViewContentForH];
     }
     

--- a/ESJsonFormatForMac/Utils/FileManager.m
+++ b/ESJsonFormatForMac/Utils/FileManager.m
@@ -45,7 +45,7 @@
          newMContent = [NSString stringWithFormat:@"%@%@%@",modelStr,mImportStr,mContent];
      }else{
          
-         hImportStr = [NSMutableString stringWithString:@"import UIKit\n\n"];
+         hImportStr = [NSMutableString stringWithString:@"import Foundation\n"];
          NSString *superClassString = [[NSUserDefaults standardUserDefaults] valueForKey:@"SuperClass"];
          if (superClassString&&superClassString.length>0) {
              [hImportStr appendString:[NSString stringWithFormat:@"import %@ \n\n",superClassString]];


### PR DESCRIPTION
1. Swift导出支持YYModel/MJExtension
2. OC下对MJExtension导出mapper函数增加 mj_ 前缀
3. key对应的值为数组时将数组的所有元素的key集中到一起在生成model(之前只取数组首元素)